### PR TITLE
Add more functionality to extract Product Code and properly format for better uninstall.

### DIFF
--- a/Common/Get-MSIFileInformation.ps1
+++ b/Common/Get-MSIFileInformation.ps1
@@ -1,0 +1,42 @@
+﻿Function Get-MSIFileInformation
+{
+param(
+    [parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [System.IO.FileInfo]$Path,
+ 
+    [parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [ValidateSet("ProductCode", "ProductVersion", "ProductName", "Manufacturer", "ProductLanguage", "FullVersion")]
+    [string]$Property
+)
+  Process {
+        try {
+            # Read property from MSI database
+            $WindowsInstaller = New-Object -ComObject WindowsInstaller.Installer
+            $MSIDatabase = $WindowsInstaller.GetType().InvokeMember("OpenDatabase", "InvokeMethod", $null, $WindowsInstaller, @($Path.FullName, 0))
+            $Query = "SELECT Value FROM Property WHERE Property = '$($Property)'"
+            $View = $MSIDatabase.GetType().InvokeMember("OpenView", "InvokeMethod", $null, $MSIDatabase, ($Query))
+            $View.GetType().InvokeMember("Execute", "InvokeMethod", $null, $View, $null)
+            $Record = $View.GetType().InvokeMember("Fetch", "InvokeMethod", $null, $View, $null)
+            $Value = $Record.GetType().InvokeMember("StringData", "GetProperty", $null, $Record, 1)
+     
+            # Commit database and close view
+            $MSIDatabase.GetType().InvokeMember("Commit", "InvokeMethod", $null, $MSIDatabase, $null)
+            $View.GetType().InvokeMember("Close", "InvokeMethod", $null, $View, $null)           
+            $MSIDatabase = $null
+            $View = $null
+     
+            # Return the value
+            return $Value
+        } 
+        catch {
+            Write-Warning -Message $_.Exception.Message ; break
+        }
+  }
+  End {
+          # Run garbage collection and release ComObject
+          [System.Runtime.Interopservices.Marshal]::ReleaseComObject($WindowsInstaller) | Out-Null
+          [System.GC]::Collect()
+  }
+}

--- a/MSIUninstall/UnInstall-BTDFApplication.ps1
+++ b/MSIUninstall/UnInstall-BTDFApplication.ps1
@@ -8,15 +8,14 @@
 . "$PSScriptRoot\Init-BTDFTasks.ps1"
 . "$PSScriptRoot\Get-MSIFileInformation.ps1"
 
+$InstallGuid = [Guid]::Empty
+
 if (-not [Guid]::TryParse($Product, [ref] $InstallGuid)) {
     if (Test-Path -Path "$Product" -ErrorAction SilentlyContinue) {
         $MSI = Get-Item -Path "$Product" -ErrorAction Stop
         $FoundMSIGuid = Get-MSIFileInformation -Path "$MSI" -Property "ProductCode"
         if (-not [Guid]::TryParse($FoundMSIGuid, [ref] $InstallGuid)) {
             $Name = [Regex]::Match($MSI.BaseName,'^(\.?[a-zA-Z]+)*').Value
-        }
-        else {
-            $InstallGuid = $FoundMSIGuid
         }
     } else {
         $Name = "$Product"
@@ -29,13 +28,10 @@ if (-not [Guid]::TryParse($Product, [ref] $InstallGuid)) {
         }
     }
 }
-else {
-    $InstallGuid = $InstallGuid.ToString("B")
-}
 
 $msiexec = 'msiexec.exe'
 $args = [string[]]@(
-    "/x $InstallGuid"
+    "/x {0:B}"  -f $InstallGuid
     "/qn"
 )
 if (-not [string]::IsNullOrWhiteSpace($Arguments)) {


### PR DESCRIPTION
Really made it more fail-proof.  I made sure that these cases work:
1) $Product parameter will work with Product Name with spaces.  The BTDF creates the name as "$(ProjectName) for BizTalk $(ProductVersion)"

2) $Product code will work with actual Guid, with and without braces.

3) $Product will work with path to MSI OR wildcard path to MSI, "C:\SomePath\*.msi".

As you can see I am using a special function in a NEW file that will parse information from an actual MSI package file.  I am extracting the Product Code and making sure it is in a valid GUID string format that msiexec can use.   Why am I doing this?  During the BTDF deployment I copy the original MSI to the install dir.  So, that later when I do another deployment next time I set the $Product parameter as a wildcard path to the install directory "C:\Program Files (x86)\ProjectName\*.msi" and thus it will use the original MSI to uninstall the original package.  I then have another step to delete the MSI after the uninstall (because it doesn't not uninstall what it didn't place there to begin with).

Please let me know what you think.