### PR TITLE
Changed file mask for finding the specific EnvironmentSettings

### DIFF
--- a/BTDFDeploy/Deploy-BTDFApplication.ps1
+++ b/BTDFDeploy/Deploy-BTDFApplication.ps1
@@ -14,7 +14,7 @@ param(
 $ApplicationPath = Join-Path $ProgramFiles $Name
 if (Test-Path -Path $ApplicationPath -ErrorAction SilentlyContinue) {
     $EnvironmentSettingsPath = Get-ChildItem -Path $ApplicationPath -Recurse -Filter 'EnvironmentSettings' | Select-Object -ExpandProperty FullName -First 1
-    $EnvironmentSettings = Join-Path $EnvironmentSettingsPath ('{0}_settings.xml' -f $Environment)
+    $EnvironmentSettings = Join-Path $EnvironmentSettingsPath ('Exported_{0}Settings.xml' -f $Environment)
     if (!(Test-Path -Path $EnvironmentSettings)) {
         $DeploymentToolsPath = Get-ChildItem -Path $ApplicationPath -Recurse -Filter 'DeployTools' | Select-Object -ExpandProperty FullName -First 1
         $esxargs = [string[]]@(


### PR DESCRIPTION
The previous version of the script had a file mask of '{0}_settings.xml', whereas the default file names generated by BTDF are 'Exported_{0}Settings.xml'.