### PR TITLE
Fixes #9 Deploy-BTDFApplication -Environment

### DIFF
--- a/BTDFDeploy/Deploy-BTDFApplication.ps1
+++ b/BTDFDeploy/Deploy-BTDFApplication.ps1
@@ -24,13 +24,13 @@ Write-Host "Name: $Name, Environment: $Environment, Destination: $Destination, B
 if (Test-Path -Path $ApplicationPath -ErrorAction SilentlyContinue) {
 	if ($Environment)
 	{
-        $EnvironmentSettingsPath = Get-ChildItem -Path $ApplicationPath -Recurse -Filter 'EnvironmentSettings' | Select-Object -ExpandProperty FullName -First 1
-        $EnvironmentSettings = Join-Path $EnvironmentSettingsPath $Environment
-        if ($Environment -notmatch '\.xml') {
-            # This offers backwards compatibility for existing tasks which are set to the environment name, not the full file name.
-            $EnvironmentSettings = "$($EnvironmentSettings)_settings.xml"
-        }
-        if (!(Test-Path -Path $EnvironmentSettings)) {
+		$EnvironmentSettingsPath = Get-ChildItem -Path $ApplicationPath -Recurse -Filter 'EnvironmentSettings' | Select-Object -ExpandProperty FullName -First 1
+		$EnvironmentSettings = Join-Path $EnvironmentSettingsPath $Environment
+		if ($Environment -notmatch '\.xml') {
+			# This offers backwards compatibility for existing tasks which are set to the environment name, not the full file name.
+			$EnvironmentSettings = "$($EnvironmentSettings)_settings.xml"
+		}
+		if (!(Test-Path -Path $EnvironmentSettings)) {
 			$DeploymentToolsPath = Get-ChildItem -Path $ApplicationPath -Recurse -Filter 'DeployTools' | Select-Object -ExpandProperty FullName -First 1
 			$esxargs = [string[]]@(
 				"`"$EnvironmentSettingsPath\\SettingsFileGenerator.xml`""

--- a/BTDFDeploy/Deploy-BTDFApplication.ps1
+++ b/BTDFDeploy/Deploy-BTDFApplication.ps1
@@ -24,9 +24,13 @@ Write-Host "Name: $Name, Environment: $Environment, Destination: $Destination, B
 if (Test-Path -Path $ApplicationPath -ErrorAction SilentlyContinue) {
 	if ($Environment)
 	{
-		$EnvironmentSettingsPath = Get-ChildItem -Path $ApplicationPath -Recurse -Filter 'EnvironmentSettings' | Select-Object -ExpandProperty FullName -First 1
-		$EnvironmentSettings = Join-Path $EnvironmentSettingsPath ('{0}_settings.xml' -f $Environment)
-		if (!(Test-Path -Path $EnvironmentSettings)) {
+        $EnvironmentSettingsPath = Get-ChildItem -Path $ApplicationPath -Recurse -Filter 'EnvironmentSettings' | Select-Object -ExpandProperty FullName -First 1
+        $EnvironmentSettings = Join-Path $EnvironmentSettingsPath $Environment
+        if ($Environment -notmatch '\.xml') {
+            # This offers backwards compatibility for existing tasks which are set to the environment name, not the full file name.
+            $EnvironmentSettings = "$($EnvironmentSettings)_settings.xml"
+        }
+        if (!(Test-Path -Path $EnvironmentSettings)) {
 			$DeploymentToolsPath = Get-ChildItem -Path $ApplicationPath -Recurse -Filter 'DeployTools' | Select-Object -ExpandProperty FullName -First 1
 			$esxargs = [string[]]@(
 				"`"$EnvironmentSettingsPath\\SettingsFileGenerator.xml`""

--- a/BTDFDeploy/task.json
+++ b/BTDFDeploy/task.json
@@ -5,7 +5,10 @@
   "description": "Deployment Framework for BizTalk btdfproj project target: Deploy",
   "author": "Jason Vercellone",
   "helpMarkDown": "",
-  "category": "Deploy",
+  "category": [
+    "Azure Pipelines",
+    "Deploy"
+  ],
   "visibility": [
     "Release"
   ],
@@ -13,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "0",
-    "Patch": "1"
+    "Patch": "2"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Deploy: $(Name)",
@@ -32,7 +35,7 @@
       "label": "Environment",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "The BTDF environment name, used as a prefix to the settings file name (i.e. '{0}_settings.xml'). Leave blank to skip EnvironmentSettings export."
+      "helpMarkDown": "The environment-specific 'Settings file name:' as shown in your SettingsFileGenerator.xml.  If the .xml extension is excluded, '_settings.xml' will be appended for backwards compatibility.  Leave blank to skip EnvironmentSettings export."
     },
     {
       "name": "Destination",

--- a/BTDFUndeploy/task.json
+++ b/BTDFUndeploy/task.json
@@ -5,7 +5,10 @@
   "description": "Deployment Framework for BizTalk btdfproj project target: Undeploy",
   "author": "Jason Vercellone",
   "helpMarkDown": "",
-  "category": "Deploy",
+  "category": [
+    "Azure Pipelines",
+    "Deploy"
+  ],
   "visibility": [
     "Release"
   ],
@@ -13,7 +16,7 @@
   "version": {
     "Major": "1",
     "Minor": "0",
-    "Patch": "0"
+    "Patch": "1"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "UnDeploy: $(Name)",

--- a/BizTalkTerminateSuspended/task.json
+++ b/BizTalkTerminateSuspended/task.json
@@ -5,15 +5,18 @@
   "description": "Terminates suspended service instances and optionally saves the relevant messages and metadata",
   "author": "Jason Vercellone",
   "helpMarkDown": "",
-  "category": "Deploy",
+  "category": [
+    "Azure Pipelines",
+    "Deploy"
+  ],
   "visibility": [
     "Release"
   ],
   "demands": [],
   "version": {
-    "Major": "0",
+    "Major": "1",
     "Minor": "0",
-    "Patch": "5"
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Terminate Suspended",

--- a/MSIInstall/task.json
+++ b/MSIInstall/task.json
@@ -5,15 +5,18 @@
   "description": "Install an MSI using the command msiexec.exe /i [msi file]",
   "author": "Jason Vercellone",
   "helpMarkDown": "",
-  "category": "Deploy",
+  "category": [
+    "Azure Pipelines",
+    "Deploy"
+  ],
   "visibility": [
     "Release"
   ],
   "demands": [],
   "version": {
-    "Major": "0",
+    "Major": "1",
     "Minor": "0",
-    "Patch": "12"
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Install: $(Name)",

--- a/MSIUninstall/task.json
+++ b/MSIUninstall/task.json
@@ -5,15 +5,18 @@
   "description": "Uninstall an MSI using the command msiexec.exe /x[InstallGuid]",
   "author": "Jason Vercellone",
   "helpMarkDown": "",
-  "category": "Deploy",
+  "category": [
+    "Azure Pipelines",
+    "Deploy"
+  ],
   "visibility": [
     "Release"
   ],
   "demands": [],
   "version": {
-    "Major": "0",
+    "Major": "1",
     "Minor": "0",
-    "Patch": "7"
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Uninstall: $(Product)",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
       - master
 
   environment:
-    # Set your VSTS Personal Access Token to facilitate publishing
+    # Set your Azure DevOps Personal Access Token to facilitate publishing
     # Don't store it in the clear, encrypt it: https://ci.appveyor.com/tools/encrypt
     VSTS_PAT:
       secure: H/UHOP7KVeCcaTkvMe7cp9pn8RlCdvQUOUajO0urYVaL8rr2VbLA+/oJTd+0nRvngg5ZJxwexPLdAKc2oxaxtQ==

--- a/overview.md
+++ b/overview.md
@@ -1,6 +1,6 @@
-# Deployment Framework for BizTalk VSTS release tasks
+# Deployment Framework for BizTalk Azure DevOps release tasks
 
-This extension facilitates the release (not build) of BizTalk applications to server(s) with a [private agent](https://www.visualstudio.com/en-us/docs/build/concepts/agents/agents) (deployment group members qualify).  It started as a decomposition of the monolithic [Install-BizTalkApplication](http://biztalkalm.codeplex.com/SourceControl/latest#Prod/BuildScripts/Install-BizTalkApplication.ps1) PowerShell script into more granular tasks for greater flexibility and enhanced feedback within the scope of a vsts release.
+This extension facilitates the deployment (not build) of BizTalk applications to server(s) with a [private agent](https://www.visualstudio.com/en-us/docs/build/concepts/agents/agents) (deployment group members qualify).  It started as a decomposition of the Randy Paulo's monolithic [Install-BizTalkApplication](https://gallery.technet.microsoft.com/Powershell-Script-to-903a99c2) PowerShell script into more granular tasks for greater flexibility and enhanced feedback within the scope of a Azure DevOps pipeline.
 
 The BTDF Deploy/Undeploy tasks require artifacts built using the [Deployment Framework for BizTalk (BTDF)](http://biztalkdeployment.codeplex.com/).  For those unfamiliar, I recommend starting with Thomas F. Abraham's recently published [Deployment Framework for BizTalk Visual Studio extensions](https://marketplace.visualstudio.com/items?itemName=DeployFxForBizTalkTeam.DeploymentFrameworkforBizTalk).
 
@@ -71,5 +71,5 @@ In the following step you use an agent for the MgmtDB deploy.
 * [Deployment Framework for BizTalk (BTDF)](http://biztalkdeployment.codeplex.com/)
 * [Deployment Framework For BizTalk Documentation](http://www.tfabraham.com/blog/deployment-[framework-for-biztalk-documentation/)
 * [Understanding the BizTalk Deployment Framework – Introduction](https://blogs.biztalk360.com/understanding-biztalk-deployment-framework-introduction/)
-* [BizTalk ALM with VSTS](http://biztalkersblog.azurewebsites.net/biztalk-alm-with-visual-studio-online/)
+* [BizTalk ALM with Visual Studio Online](http://biztalkersblog.azurewebsites.net/biztalk-alm-with-visual-studio-online/)
 * [BizTalk Application Deployment using BTDF and PowerShell](https://vikas15bhardwaj.wordpress.com/2015/02/06/biztalk-application-deployment-using-btdf-and-powershell/)

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -9,14 +9,14 @@
             "id": "Microsoft.VisualStudio.Services"
         }
     ],    
-    "description": "Deployment Framework for BizTalk VSTS release tasks.",
+    "description": "Deployment Framework for BizTalk Azure DevOps pipeline tasks.",
     "categories": [
         "Azure Pipelines"
     ],
     "tags": [
         "BizTalk",
         "BTDF",
-		"MSI",
+        "MSI",
         "tasks"
     ],
     "icons": {
@@ -24,7 +24,7 @@
     },
     "links": {
         "getstarted": {
-            "uri": "https://github.com/vercellone"
+            "uri": "https://github.com/vercellone/vsts-btdf-tasks"
         }
 	},
     "content": {
@@ -33,8 +33,7 @@
         }
     },
     "galleryFlags": [
-        "Public",
-        "Preview"
+        "Public"
     ],
     "files": [
         {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "btdf-tasks",
     "name": "Deployment Framework for BizTalk",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "publisher": "vercellj",
     "targets": [
         {


### PR DESCRIPTION
Environment helpMarkDown: "The environment-specific 'Settings file name:' as shown in your SettingsFileGenerator.xml.  If the .xml extension is excluded, '_settings.xml' will be appended for backward compatibility.  Leave blank to skip EnvironmentSettings export."

I was tempted to set the default value to "Exported_$(Release.EnvironmentName)settings.xml", but resisted for the sake of backward compatibility.

And, a few aesthetic changes
- VSTS =>Azure DevOps
- Release => Deployment or Pipeline
- minor overview.md changes
